### PR TITLE
fix for log files with empty stack traces

### DIFF
--- a/analyzer.js
+++ b/analyzer.js
@@ -62,7 +62,7 @@ function analyze(log) {
 		else {
 			const found = line.match(RE.STRACE);
 			if ( found && site ) {
-				const desc = _strace[found[2]];
+				const desc = _strace[found[2]] || "no-trace-available";
 				const key = hash('md5').update(desc).digest('hex');;
 				let count;
 


### PR DESCRIPTION
Some logs does not have content after stack trace line. for example, "Stack trace <ref:xxxxxxxxxxxxxxxxxxxxxxx>".
This was breaking md5 update.